### PR TITLE
External account balance evolution fix

### DIFF
--- a/BudgetManager/mvc/views/SavingAccountForm.cs
+++ b/BudgetManager/mvc/views/SavingAccountForm.cs
@@ -148,7 +148,7 @@ namespace BudgetManager.mvc.views {
 
                 int j = 0;//the index of the current row from the DataTable object retrieved from the DB
                 for (int i = 0; i < chart.Series[0].Points.Count; i++) {                    
-                    //If there are no more rows in the DataTable(for example there may be months for which there are no records) the ) value is added to the respectiv month from the chart
+                    //If there are no more rows in the DataTable(for example there may be months for which there are no records) the 0 value is added to the respectiv month from the chart
                     if (j > inputDataTable.Rows.Count - 1) {
                         chart.Series[0].Points[i].SetValueY(0);
                         continue;

--- a/BudgetManager/mvp/views/ExternalAccountStatisticsForm.Designer.cs
+++ b/BudgetManager/mvp/views/ExternalAccountStatisticsForm.Designer.cs
@@ -504,6 +504,13 @@
             series3.Color = System.Drawing.Color.Lime;
             series3.Legend = "Legend1";
             series3.Name = "Monthly balance";
+            dataPoint1.Label = "";
+            dataPoint1.LabelToolTip = "";
+            dataPoint8.Label = "Aug";
+            dataPoint9.Label = "Sep";
+            dataPoint10.Label = "Oct";
+            dataPoint11.Label = "Nov";
+            dataPoint12.Label = "Dec";
             series3.Points.Add(dataPoint1);
             series3.Points.Add(dataPoint2);
             series3.Points.Add(dataPoint3);

--- a/BudgetManager/mvp/views/ExternalAccountStatisticsForm.cs
+++ b/BudgetManager/mvp/views/ExternalAccountStatisticsForm.cs
@@ -39,7 +39,7 @@ namespace BudgetManager.mvp.views {
             this.userId = userId;
             InitializeComponent();
             associateAndRaiseEvents();
-            userAccountsComboBox.SelectedIndex = -1;
+            userAccountsComboBox.SelectedItem = null;
             selectedItemType = BudgetItemType.ACCOUNT_TRANSFER;//The transfers item type will always be selected by default
         }
 


### PR DESCRIPTION
External account balance evolution fix: (#37)
    -fixes the SELECT which retrieves the external account balance evolution
    so that it shows correct data for each month of the year
    -fixes the SELECT which retrieves the user's external accounts by adding
    specific condition for this type of account

